### PR TITLE
Compute include-type flag when creating template. Close #1

### DIFF
--- a/config/samples/elastic_v1alpha1_elasticindex.yaml
+++ b/config/samples/elastic_v1alpha1_elasticindex.yaml
@@ -16,20 +16,18 @@ spec:
       "settings": {
       },
       "mappings": {
-        "_doc": {
-          "_source": {
-            "enabled": true
+        "_source": {
+          "enabled": true
+        },
+        "dynamic": false,
+        "properties": {
+          "barcode": {
+            "type": "keyword",
+            "index": true
           },
-          "dynamic": false,
-          "properties": {
-            "barcode": {
-              "type": "keyword",
-              "index": true
-            },
-            "description": {
-              "type": "text",
-              "index": true
-            }
+          "description": {
+            "type": "text",
+            "index": true
           }
         }
       }
@@ -56,20 +54,18 @@ spec:
         "number_of_replicas" : "3"
       },
       "mappings": {
-        "_doc": {
-          "_source": {
-            "enabled": true
+        "_source": {
+          "enabled": true
+        },
+        "dynamic": false,
+        "properties": {
+          "cityCode": {
+            "type": "keyword",
+            "index": true
           },
-          "dynamic": false,
-          "properties": {
-            "cityCode": {
-              "type": "keyword",
-              "index": true
-            },
-            "cityName": {
-              "type": "text",
-              "index": true
-            }
+          "cityName": {
+            "type": "text",
+            "index": true
           }
         }
       }

--- a/pkg/utils/elasticsearch.go
+++ b/pkg/utils/elasticsearch.go
@@ -348,10 +348,11 @@ func (es *Elasticsearch) DeleteIndex(indexName string) error {
 	return nil
 }
 
-func (es *Elasticsearch) CreateOrUpdateTemplate(templateName string, body string) (*EsStatus, error) {
+func (es *Elasticsearch) CreateOrUpdateTemplate(templateName string, model string) (*EsStatus, error) {
 	exists := es.existsTemplate(templateName)
 
-	response, err := es.Client.Indices.PutTemplate(templateName, strings.NewReader(body))
+	shouldIncludeTypeName := (&EsModel{Model: model}).IsMappingWithType()
+	response, err := esapi.IndicesPutTemplateRequest{Name: templateName, Body: strings.NewReader(model), IncludeTypeName: shouldIncludeTypeName}.Do(context.Background(), es.Client)
 	if err != nil || exists == nil {
 		es.log.Error(err, "error while creating template", "templateName", templateName)
 		return &EsStatus{Status: StatusError, Message: err.Error()}, err

--- a/pkg/utils/elasticsearch_test.go
+++ b/pkg/utils/elasticsearch_test.go
@@ -282,7 +282,20 @@ func TestElasticsearch_CreateOrUpdateTemplate(t *testing.T) {
 
 	templateName := "k8s_epo_test_create_template"
 
-	status, err := elasticsearch.CreateOrUpdateTemplate(templateName, `{"index_patterns": ["k8s_epo_test_*"]}`)
+	status, err := elasticsearch.CreateOrUpdateTemplate(templateName, `{"index_patterns": ["k8s_epo_test_*"], "mappings": {"properties": {}}}`)
+	assert.Nil(err)
+	assert.Equal("200", status.HttpCodeStatus)
+	assert.True(*elasticsearch.existsTemplate(templateName))
+}
+
+func TestElasticsearch_CreateOrUpdateTemplate_WithType(t *testing.T) {
+	assert := assert.New(t)
+	elasticsearch := buildElasticsearch(t)
+	defer deleteAll(elasticsearch)
+
+	templateName := "k8s_epo_test_create_template_with_type"
+
+	status, err := elasticsearch.CreateOrUpdateTemplate(templateName, `{"index_patterns": ["k8s_epo_test_*"], "mappings": {"my-type": {"properties": {}}}}`)
 	assert.Nil(err)
 	assert.Equal("200", status.HttpCodeStatus)
 	assert.True(*elasticsearch.existsTemplate(templateName))


### PR DESCRIPTION
Compute if we should include type when creating a template to be compatible with elasticsearch 6+ (process implemented for indices).
This PR should fix issue https://github.com/Carrefour-Group/elastic-phenix-operator/issues/1

Although we can create `elasticindex` / `elastictemplate` with type, I prefer delete `types` from samples (`types` are deprecated since elasticsearch 6).